### PR TITLE
Server API Fixes

### DIFF
--- a/lib/Model/Server.php
+++ b/lib/Model/Server.php
@@ -51,6 +51,7 @@ class Server implements ArrayAccess
         'hostname' => 'string',
         'ip_addresses' => '\Upcloud\ApiClient\Model\IpAddresses',
         'license' => 'float',
+        'login_user' => '\Upcloud\ApiClient\Model\ServerLoginUser',
         'memory_amount' => 'float',
         'nic_model' => 'string',
         'plan' => 'string',
@@ -82,6 +83,7 @@ class Server implements ArrayAccess
         'hostname' => null,
         'ip_addresses' => null,
         'license' => null,
+        'login_user' => null,
         'memory_amount' => null,
         'nic_model' => null,
         'plan' => null,
@@ -123,6 +125,7 @@ class Server implements ArrayAccess
         'hostname' => 'hostname',
         'ip_addresses' => 'ip_addresses',
         'license' => 'license',
+        'login_user' => 'login_user',
         'memory_amount' => 'memory_amount',
         'nic_model' => 'nic_model',
         'plan' => 'plan',
@@ -155,6 +158,7 @@ class Server implements ArrayAccess
         'hostname' => 'setHostname',
         'ip_addresses' => 'setIpAddresses',
         'license' => 'setLicense',
+        'login_user' => 'setLoginUser',
         'memory_amount' => 'setMemoryAmount',
         'nic_model' => 'setNicModel',
         'plan' => 'setPlan',
@@ -187,6 +191,7 @@ class Server implements ArrayAccess
         'hostname' => 'getHostname',
         'ip_addresses' => 'getIpAddresses',
         'license' => 'getLicense',
+        'login_user' => 'getLoginUser',
         'memory_amount' => 'getMemoryAmount',
         'nic_model' => 'getNicModel',
         'plan' => 'getPlan',
@@ -304,6 +309,7 @@ class Server implements ArrayAccess
         $this->container['hostname'] = isset($data['hostname']) ? $data['hostname'] : null;
         $this->container['ip_addresses'] = isset($data['ip_addresses']) ? $data['ip_addresses'] : null;
         $this->container['license'] = isset($data['license']) ? $data['license'] : null;
+        $this->container['login_user'] = isset($data['login_user']) ? $data['login_user'] : null;
         $this->container['memory_amount'] = isset($data['memory_amount']) ? $data['memory_amount'] : null;
         $this->container['nic_model'] = isset($data['nic_model']) ? $data['nic_model'] : 'e1000';
         $this->container['plan'] = isset($data['plan']) ? $data['plan'] : 'custom';
@@ -557,6 +563,27 @@ class Server implements ArrayAccess
     public function setLicense($license)
     {
         $this->container['license'] = $license;
+
+        return $this;
+    }
+
+    /**
+     * Gets login user
+     * @return \Upcloud\ApiClient\Model\ServerLoginUser
+     */
+    public function getLoginUser()
+    {
+        return $this->container['login_user'];
+    }
+
+    /**
+     * Sets login user
+     * @param \Upcloud\ApiClient\Model\ServerLoginUser $login_user
+     * @return $this
+     */
+    public function setLoginUser($login_user)
+    {
+        $this->container['login_user'] = $login_user;
 
         return $this;
     }

--- a/lib/Model/ServerLoginUser.php
+++ b/lib/Model/ServerLoginUser.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * ServerLoginUser
+ *
+ * PHP version 5
+ *
+ * @category Class
+ * @package  Upcloud\ApiClient
+ */
+
+/**
+ * Upcloud api
+ *
+ * The UpCloud API consists of operations used to control resources on UpCloud. The API is a web service interface. HTTPS is used to connect to the API. The API follows the principles of a RESTful web service wherever possible. The base URL for all API operations is  https://api.upcloud.com/. All API operations require authentication.
+ *
+ * OpenAPI spec version: 1.2.0
+ * 
+ */
+
+
+namespace Upcloud\ApiClient\Model;
+
+use \ArrayAccess;
+
+/**
+ * ServerLoginUser Class Doc Comment
+ *
+ * @category    Class
+ * @package     Upcloud\ApiClient
+ */
+class ServerLoginUser implements ArrayAccess
+{
+    const DISCRIMINATOR = null;
+
+    /**
+      * The original name of the model.
+      * @var string
+      */
+    protected static $swaggerModelName = 'Login_user';
+
+    /**
+      * Array of property to type mappings. Used for (de)serialization
+      * @var string[]
+      */
+    protected static $swaggerTypes = [
+        'create_password' => 'string',
+        'username' => 'string',
+        'ssh_keys' => '\Upcloud\ApiClient\Model\SshKeys'
+    ];
+
+    /**
+      * Array of property to format mappings. Used for (de)serialization
+      * @var string[]
+      */
+    protected static $swaggerFormats = [
+        'create_password' => null,
+        'username' => null,
+        'ssh_keys' => null
+    ];
+
+    public static function swaggerTypes()
+    {
+        return self::$swaggerTypes;
+    }
+
+    public static function swaggerFormats()
+    {
+        return self::$swaggerFormats;
+    }
+
+    /**
+     * Array of attributes where the key is the local name, and the value is the original name
+     * @var string[]
+     */
+    protected static $attributeMap = [
+        'create_password' => 'create_password',
+        'username' => 'username',
+        'ssh_keys' => 'ssh_keys'
+    ];
+
+
+    /**
+     * Array of attributes to setter functions (for deserialization of responses)
+     * @var string[]
+     */
+    protected static $setters = [
+        'create_password' => 'setCreatePassword',
+        'username' => 'setUsername',
+        'ssh_keys' => 'setSshKeys'
+    ];
+
+
+    /**
+     * Array of attributes to getter functions (for serialization of requests)
+     * @var string[]
+     */
+    protected static $getters = [
+        'create_password' => 'getCreatePassword',
+        'username' => 'getUsername',
+        'ssh_keys' => 'getSshKeys'
+    ];
+
+    public static function attributeMap()
+    {
+        return self::$attributeMap;
+    }
+
+    public static function setters()
+    {
+        return self::$setters;
+    }
+
+    public static function getters()
+    {
+        return self::$getters;
+    }
+
+    const CREATE_PASSWORD_YES = 'yes';
+    const CREATE_PASSWORD_NO = 'no';
+
+    /**
+     * Gets allowable values of the enum
+     * @return string[]
+     */
+    public function getCreatePasswordAllowableValues()
+    {
+        return [
+            self::CREATE_PASSWORD_YES,
+            self::CREATE_PASSWORD_NO,
+        ];
+    }
+
+    
+
+    /**
+     * Associative array for storing property values
+     * @var mixed[]
+     */
+    protected $container = [];
+
+    /**
+     * Constructor
+     * @param mixed[] $data Associated array of property values initializing the model
+     */
+    public function __construct(array $data = null)
+    {
+        $this->container['create_password'] = isset($data['create_password']) ? $data['create_password'] : null;
+        $this->container['username'] = isset($data['username']) ? $data['username'] : null;
+        $this->container['ssh_keys'] = isset($data['ssh_keys']) ? $data['ssh_keys'] : null;
+    }
+
+    /**
+     * show all the invalid properties with reasons.
+     *
+     * @return array invalid properties with reasons
+     */
+    public function listInvalidProperties()
+    {
+        $invalid_properties = [];
+
+        $allowed_values = $this->getCreatePasswordAllowableValues();
+        if (!in_array($this->container['create_password'], $allowed_values)) {
+            $invalid_properties[] = sprintf(
+                "invalid value for 'create_password', must be one of '%s'",
+                implode("', '", $allowed_values)
+            );
+        }
+
+        return $invalid_properties;
+    }
+
+    /**
+     * validate all the properties in the model
+     * return true if all passed
+     *
+     * @return bool True if all properties are valid
+     */
+    public function valid()
+    {
+        $allowed_values = $this->getCreatePasswordAllowableValues();
+        if (!in_array($this->container['create_password'], $allowed_values)) {
+            return false;
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Gets create password
+     * @return string
+     */
+    public function getCreatePassword()
+    {
+        return $this->container['create_password'];
+    }
+
+    /**
+     * Sets create password
+     * @param string $create_password
+     * @return $this
+     */
+    public function setCreatePassword($create_password)
+    {
+        $this->container['create_password'] = $create_password;
+
+        return $this;
+    }
+
+    /**
+     * Gets username
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->container['username'];
+    }
+
+    /**
+     * Sets username
+     * @param string $username
+     * @return $this
+     */
+    public function setUsername($username)
+    {
+        $this->container['username'] = $username;
+
+        return $this;
+    }
+
+    /**
+     * Gets ssh keys
+     * @return \Upcloud\ApiClient\Model\SshKeys
+     */
+    public function getSshKeys()
+    {
+        return $this->container['ssh_keys'];
+    }
+
+    /**
+     * Sets ssh keys
+     * @param \Upcloud\ApiClient\Model\SshKeys $ssh_keys
+     * @return $this
+     */
+    public function setSshKeys($ssh_keys)
+    {
+        $this->container['ssh_keys'] = $ssh_keys;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if offset exists. False otherwise.
+     * @param  integer $offset Offset
+     * @return boolean
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->container[$offset]);
+    }
+
+    /**
+     * Gets offset.
+     * @param  integer $offset Offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return isset($this->container[$offset]) ? $this->container[$offset] : null;
+    }
+
+    /**
+     * Sets value based on offset.
+     * @param  integer $offset Offset
+     * @param  mixed   $value  Value to be set
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->container[] = $value;
+        } else {
+            $this->container[$offset] = $value;
+        }
+    }
+
+    /**
+     * Unsets offset.
+     * @param  integer $offset Offset
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->container[$offset]);
+    }
+
+    /**
+     * Gets the string presentation of the object
+     * @return string
+     */
+    public function __toString()
+    {
+        if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
+            return json_encode(\Upcloud\ApiClient\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+        }
+
+        return json_encode(\Upcloud\ApiClient\ObjectSerializer::sanitizeForSerialization($this));
+    }
+}
+
+

--- a/lib/Model/SshKeys.php
+++ b/lib/Model/SshKeys.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * SshKeys
+ *
+ * PHP version 5
+ *
+ * @category Class
+ * @package  Upcloud\ApiClient
+ */
+
+/**
+ * Upcloud api
+ *
+ * The UpCloud API consists of operations used to control resources on UpCloud. The API is a web service interface. HTTPS is used to connect to the API. The API follows the principles of a RESTful web service wherever possible. The base URL for all API operations is  https://api.upcloud.com/. All API operations require authentication.
+ *
+ * OpenAPI spec version: 1.2.0
+ * 
+ */
+
+
+namespace Upcloud\ApiClient\Model;
+
+use \ArrayAccess;
+
+/**
+ * SshKeys Class Doc Comment
+ *
+ * @category    Class
+ * @package     Upcloud\ApiClient
+ */
+class SshKeys implements ArrayAccess
+{
+    const DISCRIMINATOR = null;
+
+    /**
+      * The original name of the model.
+      * @var string
+      */
+    protected static $swaggerModelName = 'Ssh_keys';
+
+    /**
+      * Array of property to type mappings. Used for (de)serialization
+      * @var string[]
+      */
+    protected static $swaggerTypes = [
+        'ssh_key' => 'string[]'
+    ];
+
+    /**
+      * Array of property to format mappings. Used for (de)serialization
+      * @var string[]
+      */
+    protected static $swaggerFormats = [
+        'ssh_key' => null
+    ];
+
+    public static function swaggerTypes()
+    {
+        return self::$swaggerTypes;
+    }
+
+    public static function swaggerFormats()
+    {
+        return self::$swaggerFormats;
+    }
+
+    /**
+     * Array of attributes where the key is the local name, and the value is the original name
+     * @var string[]
+     */
+    protected static $attributeMap = [
+        'ssh_key' => 'ssh_key'
+    ];
+
+
+    /**
+     * Array of attributes to setter functions (for deserialization of responses)
+     * @var string[]
+     */
+    protected static $setters = [
+        'ssh_key' => 'setSshKey'
+    ];
+
+
+    /**
+     * Array of attributes to getter functions (for serialization of requests)
+     * @var string[]
+     */
+    protected static $getters = [
+        'ssh_key' => 'getSshKey'
+    ];
+
+    public static function attributeMap()
+    {
+        return self::$attributeMap;
+    }
+
+    public static function setters()
+    {
+        return self::$setters;
+    }
+
+    public static function getters()
+    {
+        return self::$getters;
+    }
+
+    /**
+     * Associative array for storing property values
+     * @var mixed[]
+     */
+    protected $container = [];
+
+    /**
+     * Constructor
+     * @param mixed[] $data Associated array of property values initializing the model
+     */
+    public function __construct(array $data = null)
+    {
+        $this->container['ssh_key'] = isset($data['ssh_key']) ? $data['ssh_key'] : null;
+    }
+
+    /**
+     * show all the invalid properties with reasons.
+     *
+     * @return array invalid properties with reasons
+     */
+    public function listInvalidProperties()
+    {
+        $invalid_properties = [];
+
+        return $invalid_properties;
+    }
+
+    /**
+     * validate all the properties in the model
+     * return true if all passed
+     *
+     * @return bool True if all properties are valid
+     */
+    public function valid()
+    {
+
+        return true;
+    }
+
+
+    /**
+     * Gets ssh key
+     * @return string[]
+     */
+    public function getSshKey()
+    {
+        return $this->container['ssh_key'];
+    }
+
+    /**
+     * Sets ssh key
+     * @param string[] $ssh_key
+     * @return $this
+     */
+    public function setSshKey($ssh_key)
+    {
+        $this->container['ssh_key'] = $ssh_key;
+
+        return $this;
+    }
+    /**
+     * Returns true if offset exists. False otherwise.
+     * @param  integer $offset Offset
+     * @return boolean
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->container[$offset]);
+    }
+
+    /**
+     * Gets offset.
+     * @param  integer $offset Offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        return isset($this->container[$offset]) ? $this->container[$offset] : null;
+    }
+
+    /**
+     * Sets value based on offset.
+     * @param  integer $offset Offset
+     * @param  mixed   $value  Value to be set
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->container[] = $value;
+        } else {
+            $this->container[$offset] = $value;
+        }
+    }
+
+    /**
+     * Unsets offset.
+     * @param  integer $offset Offset
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->container[$offset]);
+    }
+
+    /**
+     * Gets the string presentation of the object
+     * @return string
+     */
+    public function __toString()
+    {
+        if (defined('JSON_PRETTY_PRINT')) { // use JSON pretty print
+            return json_encode(\Upcloud\ApiClient\ObjectSerializer::sanitizeForSerialization($this), JSON_PRETTY_PRINT);
+        }
+
+        return json_encode(\Upcloud\ApiClient\ObjectSerializer::sanitizeForSerialization($this));
+    }
+}
+
+

--- a/lib/Upcloud/ServerApi.php
+++ b/lib/Upcloud/ServerApi.php
@@ -1326,13 +1326,14 @@ class ServerApi
      * Delete server
      *
      * @param string $server_id Id of server to delete (required)
+     * @param bool $delete_storage Delete attached storage devices
      * @throws \Upcloud\ApiClient\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function deleteServer($server_id)
+    public function deleteServer($server_id, $delete_storage = false)
     {
-        $this->deleteServerWithHttpInfo($server_id);
+        $this->deleteServerWithHttpInfo($server_id, $delete_storage);
     }
 
     /**
@@ -1341,14 +1342,15 @@ class ServerApi
      * Delete server
      *
      * @param string $server_id Id of server to delete (required)
+     * @param bool $delete_storage Delete attached storage devices
      * @throws \Upcloud\ApiClient\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deleteServerWithHttpInfo($server_id)
+    public function deleteServerWithHttpInfo($server_id, $delete_storage = false)
     {
         $returnType = '';
-        $request = $this->deleteServerRequest($server_id);
+        $request = $this->deleteServerRequest($server_id, $delete_storage);
 
         try {
 
@@ -1446,10 +1448,12 @@ class ServerApi
      * Create request for operation 'deleteServer'
      *
      * @param string $server_id Id of server to delete (required)
+     * @param bool $delete_storage Delete attached storage devices
+     *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function deleteServerRequest($server_id)
+    protected function deleteServerRequest($server_id, $delete_storage = false)
     {
         // verify the required parameter 'server_id' is set
         if ($server_id === null) {
@@ -1458,7 +1462,7 @@ class ServerApi
 
         $resourcePath = '/server/{serverId}';
         $formParams = [];
-        $queryParams = [];
+        $queryParams = $delete_storage ? ['storages' => '1'] : [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;

--- a/test/Api/ServerApiTest.php
+++ b/test/Api/ServerApiTest.php
@@ -42,10 +42,9 @@ const defaultServer = [
     "storage_devices" => [
         "storage_device" => [
             [
-                "action" => "clone",
-                "title" => "Debian from a template",
-                "size" => 30,
-                "storage" => "01000000-0000-4000-8000-000020030100",
+                "action" => "create",
+                "title" => "Debian from scratch",
+                "size" => 20,
                 "tier" => "maxiops"
             ]
         ]

--- a/test/Helpers/ServerHelper.php
+++ b/test/Helpers/ServerHelper.php
@@ -76,7 +76,7 @@ class ServerHelper
         if ($server !== null) {
             self::stopServer($server);
             try {
-                self::$api->deleteServer($server["uuid"]);
+                self::$api->deleteServer($server["uuid"], true);
             } catch (ApiException $e) {
                 echo "Error deleting: " . $e->getMessage() . "\n";
                 flush();
@@ -109,13 +109,15 @@ class ServerHelper
             try {
                 $server = self::$api->serverDetails($server["uuid"])["server"];
                 if ($server["state"] != ServerState::STOPPED) {
-                    echo "Stopping server...\n";
-                    $server = self::$api->stopServer($server["uuid"], new StopServer([
-                        "stop_server" => [
-                            "stop_type" => StopServerRequest::STOP_TYPE_HARD,
-                            "timeout" => 60
-                        ]
-                    ]))["server"];
+                    if ($server["state"] != ServerState::MAINTENANCE) {
+                        echo "Stopping server...\n";
+                        $server = self::$api->stopServer($server["uuid"], new StopServer([
+                            "stop_server" => [
+                                "stop_type" => StopServerRequest::STOP_TYPE_HARD,
+                                "timeout" => 60
+                            ]
+                        ]))["server"];
+                    }
                     sleep(15);
                     self::stopServer($server, $tryings + 1);
                 } else {


### PR DESCRIPTION
- Fixes issue #28 by adding parameter `$delete_storage` to `ServerApi::deleteServer()`, which deletes attached storage

- Fixes issue #25 by implementing models for the `login_user` attribute of the `Server` model

- Fixes `ServerApiTest` so all tests in that class pass with no errors:
  - Removes hard-coded storage UUID and switches to "create" storage action
  - Uses new delete storage flag so storage devices are not orphaned after running test suite
  - Re-tries server stop procedure if server is in "maintenance" state
  - Uses `Server` models instead of straight array in test server definition, for clearer documentation and coverage of those classes
 