### PR TITLE
Added support for multiple firewall rule creation

### DIFF
--- a/lib/Model/FirewallRulesRequest.php
+++ b/lib/Model/FirewallRulesRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upcloud\ApiClient\Model;
+
+use Upcloud\ApiClient\HttpClient\UpcloudApiRequest;
+
+class FirewallRulesRequest extends UpcloudApiRequest
+{
+    /**
+     * @var FirewallRule[]
+     */
+    private $firewallRules = [
+        'firewall_rule' => []
+    ];
+
+    /**
+     * Constructor
+     * @param mixed[] $data
+     */
+    public function __construct(array $data = null)
+    {
+        parent::__construct();
+        $this->setFirewallRules($data['firewall_rules'] ?? []);
+    }
+
+    /**
+     * @return FirewallRule[]
+     */
+    public function getFirewallRules(): array
+    {
+        return $this->firewallRules;
+    }
+
+    /**
+     * @param FirewallRule[] $firewallRules
+     * @return FirewallRulesRequest
+     */
+    public function setFirewallRules(array $firewallRules): FirewallRulesRequest
+    {
+        $this->firewallRules['firewall_rule'] = $firewallRules;
+
+        return $this;
+    }
+}

--- a/lib/Upcloud/FirewallApi.php
+++ b/lib/Upcloud/FirewallApi.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use InvalidArgumentException;
 use Upcloud\ApiClient\ApiException;
 use Upcloud\ApiClient\HttpClient\UpcloudApiResponse;
+use Upcloud\ApiClient\Model\FirewallRulesRequest;
 use Upcloud\ApiClient\Model\FirewallRuleCreateResponse;
 use Upcloud\ApiClient\Model\FirewallRuleListResponse;
 use Upcloud\ApiClient\Model\FirewallRuleRequest;
@@ -100,6 +101,88 @@ class FirewallApi extends BaseApi
 
         return $this->client->sendAsync($request)->then(function (UpcloudApiResponse $response) {
             return $response->toArray(FirewallRuleCreateResponse::class);
+        });
+    }
+
+    /**
+     * Operation createFirewallRules
+     *
+     * Create multiple firewall rules
+     *
+     * @param string $serverId Server id (required)
+     * @param FirewallRulesRequest $firewallRules  (required)
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException|GuzzleException
+     */
+    public function createFirewallRules(
+        string $serverId,
+        FirewallRulesRequest $firewallRules
+    ): void {
+        $this->createFirewallRulesWithHttpInfo($serverId, $firewallRules);
+    }
+
+    /**
+     * Operation createFirewallRulesWithHttpInfo
+     *
+     * Create multiple firewall rules
+     *
+     * @param string $serverId Server id (required)
+     * @param FirewallRulesRequest $firewallRules  (required)
+     * @return array of null, HTTP status code, HTTP response headers (array of strings)
+     * @throws InvalidArgumentException|GuzzleException
+     * @throws ApiException on non-2xx response
+     */
+    public function createFirewallRulesWithHttpInfo(
+        string $serverId,
+        FirewallRulesRequest $firewallRules
+    ): array {
+        $url = $this->buildPath('server/{serverId}/firewall_rule', compact('serverId'));
+        $request = new Request('PUT', $url, [], $firewallRules);
+
+        $response = $this->client->send($request);
+
+        return $response->toArray();
+    }
+
+    /**
+     * Operation createFirewallRulesAsync
+     *
+     * Create multiple firewall rules
+     *
+     * @param string $serverId Server id (required)
+     * @param FirewallRulesRequest $firewallRules  (required)
+     * @return PromiseInterface
+     * @throws InvalidArgumentException
+     */
+    public function createFirewallRulesAsync(
+        string $serverId,
+        FirewallRulesRequest $firewallRules
+    ): PromiseInterface {
+        return $this->createFirewallRulesAsyncWithHttpInfo($serverId, $firewallRules)->then(function ($response) {
+            return $response[0];
+        });
+    }
+
+    /**
+     * Operation createFirewallRulesAsyncWithHttpInfo
+     *
+     * Create multiple firewall rules
+     *
+     * @param string $serverId Server id (required)
+     * @param FirewallRulesRequest $firewallRules (required)
+     * @return PromiseInterface
+     * @throws InvalidArgumentException
+     */
+    public function createFirewallRulesAsyncWithHttpInfo(
+        string $serverId,
+        FirewallRulesRequest $firewallRules
+    ): PromiseInterface {
+
+        $url = $this->buildPath('server/{serverId}/firewall_rule', compact('serverId'));
+        $request = new Request('PUT', $url, [], $firewallRules);
+
+        return $this->client->sendAsync($request)->then(function (UpcloudApiResponse $response) {
+            return $response->toArray();
         });
     }
 

--- a/test/Api/FirewallApi/FirewallApiTest.php
+++ b/test/Api/FirewallApi/FirewallApiTest.php
@@ -131,6 +131,20 @@ class FirewallApiTest extends BaseApiTest
         $this->api->createFirewallRule($this->serverId, $fakeRequest);
     }
 
+    public function testCreateFirewallRules(): void
+    {
+        $fakeResponse = new Response(204, $this->fakeHeadersAsArray);
+        $fakeRequest = $this->fixture->getRulesRequestSuccess();
+        $this->mock
+            ->shouldReceive('send')
+            ->once()
+            ->andReturn($fakeResponse);
+
+        $response = $this->api->createFirewallRulesWithHttpInfo($this->serverId, $fakeRequest);
+
+        $this->assertEquals(204, $response[1]);
+    }
+
     public function testThrowsExceptionOnCreateFirewallRules(): void
     {
         $this->expectException(ApiException::class);

--- a/test/Api/FirewallApi/FirewallApiTest.php
+++ b/test/Api/FirewallApi/FirewallApiTest.php
@@ -131,6 +131,28 @@ class FirewallApiTest extends BaseApiTest
         $this->api->createFirewallRule($this->serverId, $fakeRequest);
     }
 
+    public function testThrowsExceptionOnCreateFirewallRules(): void
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionCode(400);
+        $request = new Request(
+            'POST',
+            $this->url . 'server/'.$this->serverId.'/firewall_rule',
+            $this->fakeHeadersAsArray
+        );
+
+        $response = new Response(400, $this->fakeHeadersAsArray);
+
+        $fakeRequest = $this->fixture->getRulesRequestFailed();
+
+        $this->mock
+            ->shouldReceive('send')
+            ->once()
+            ->andThrow(new RequestException('Bad Request', $request, $response));
+
+        $this->api->createFirewallRules($this->serverId, $fakeRequest);
+    }
+
     public function testThrowsExceptionOnDeleteFirewallRule(): void
     {
         $this->expectException(ApiException::class);

--- a/test/Api/Fixtures/FirewallApiFixture.php
+++ b/test/Api/Fixtures/FirewallApiFixture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Upcloud\Tests\Api\Fixtures;
 
+use Upcloud\ApiClient\Model\FirewallRulesRequest;
 use Upcloud\ApiClient\Model\FirewallRule;
 use Upcloud\ApiClient\Model\FirewallRuleCreateResponse;
 use Upcloud\ApiClient\Model\FirewallRuleListResponse;
@@ -81,6 +82,26 @@ class FirewallApiFixture extends BaseFixture
     {
         return  new FirewallRuleRequest([
             'firewall_rule' => new FirewallRule($this->getRoleByIndex($fromListIndex)),
+        ]);
+    }
+
+    /**
+     * @param int $fromListIndex
+     * @return FirewallRulesRequest
+     */
+    public function getRulesRequestFailed(int $fromListIndex = 0): FirewallRulesRequest
+    {
+        $firstRule = $this->getRoleByIndex($fromListIndex);
+        $firstRule['icmp_type'] = '255';
+
+        $secondRule = $this->getRoleByIndex($fromListIndex+1);
+        $secondRule['icmp_type'] = '255';
+
+        return new FirewallRulesRequest([
+            'firewall_rules' => [
+                new FirewallRule($firstRule),
+                new FirewallRule($secondRule),
+            ],
         ]);
     }
 

--- a/test/Api/Fixtures/FirewallApiFixture.php
+++ b/test/Api/Fixtures/FirewallApiFixture.php
@@ -89,6 +89,20 @@ class FirewallApiFixture extends BaseFixture
      * @param int $fromListIndex
      * @return FirewallRulesRequest
      */
+    public function getRulesRequestSuccess(int $fromListIndex = 0): FirewallRulesRequest
+    {
+        return new FirewallRulesRequest([
+            'firewall_rules' => [
+                new FirewallRule($this->getRoleByIndex($fromListIndex)),
+                new FirewallRule($this->getRoleByIndex($fromListIndex+1)),
+            ],
+        ]);
+    }
+
+    /**
+     * @param int $fromListIndex
+     * @return FirewallRulesRequest
+     */
     public function getRulesRequestFailed(int $fromListIndex = 0): FirewallRulesRequest
     {
         $firstRule = $this->getRoleByIndex($fromListIndex);


### PR DESCRIPTION
This PR adds support for multiple firewall rule creation by adding the `createFirewallRules` method in FirewallApi

Example usage:
```php
use Upcloud\ApiClient\Upcloud\FirewallApi;
use Upcloud\ApiClient\Model\FirewallRule;
use Upcloud\ApiClient\Model\FirewallRulesRequest;

$firewallApi = new FirewallApi();
$firewallApi->createFirewallRules(
    'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', // server id
    new FirewallRulesRequest([
        'firewall_rules' => [
            new FirewallRule([
                'family' => FirewallRule::FAMILY_IP_V4,
                'direction' => FirewallRule::DIRECTION_IN,
                'action' => FirewallRule::ACTION_ACCEPT,
                'protocol' => FirewallRule::PROTOCOL_TCP,
                'destination_port_start' => 22,
                'destination_port_end' => 22
            ]),
            new FirewallRule([
                'family' => FirewallRule::FAMILY_IP_V4,
                'direction' => FirewallRule::DIRECTION_IN,
                'action' => FirewallRule::ACTION_ACCEPT,
                'protocol' => FirewallRule::PROTOCOL_TCP,
                'destination_port_start' => 80,
                'destination_port_end' => 80
            ]),
            new FirewallRule([
                'family' => FirewallRule::FAMILY_IP_V4,
                'direction' => FirewallRule::DIRECTION_IN,
                'action' => FirewallRule::ACTION_ACCEPT,
                'protocol' => FirewallRule::PROTOCOL_ICMP
            ]),
        ]
    ])
);
```