### PR TITLE
Added support for PHP 8.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
           { os: ubuntu-latest, php: 7.3 },
           { os: ubuntu-latest, php: 7.4 },
           { os: ubuntu-latest, php: 8.0 },
+          { os: ubuntu-latest, php: 8.1 },
         ]
     runs-on: ${{ matrix.os-php-versions.os }}
     steps:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.2|^8.0",
+    "php": "^7.2|^8.0|^8.1",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",


### PR DESCRIPTION
Added support for PHP 8.1 including Github action.

I have tested the PHP unit tests - all are working fine.

Reported Issue - https://github.com/UpCloudLtd/upcloud-php-api/issues/50 
